### PR TITLE
skip bootstrapping

### DIFF
--- a/bin/entryPoint.sh
+++ b/bin/entryPoint.sh
@@ -48,7 +48,7 @@ echo "Parallel Build/Test (-j):" $NPROC
 echo "===================================="
 
 # fetch latest v8
-fetch v8
+DEPOT_TOOLS_BOOTSTRAP_PYTHON3=0 fetch v8
 cd v8
 
 # Iterate through passed features


### PR DESCRIPTION
binaries may not be available for ppc and s390x, i.e cpython3 and git:
https://chrome-infra-packages.appspot.com/p/experimental/infra/3pp/tools/cpython3
https://chrome-infra-packages.appspot.com/p/experimental/infra/3pp/tools/git