### PR TITLE
enable slow dchecks

### DIFF
--- a/bin/ppc64/debug.gn
+++ b/bin/ppc64/debug.gn
@@ -5,6 +5,7 @@ v8_enable_backtrace = true
 v8_enable_disassembler = true
 v8_enable_object_print = true
 v8_enable_verify_heap = true
+v8_enable_slow_dchecks = true
 use_custom_libcxx = false
 is_debug = true
 symbol_level = 0

--- a/bin/ppc64/ptrcompr_debug.gn
+++ b/bin/ppc64/ptrcompr_debug.gn
@@ -5,6 +5,7 @@ v8_enable_backtrace = true
 v8_enable_disassembler = true
 v8_enable_object_print = true
 v8_enable_verify_heap = true
+v8_enable_slow_dchecks = true
 use_custom_libcxx = false
 is_debug = true
 symbol_level = 0

--- a/bin/s390x/debug.gn
+++ b/bin/s390x/debug.gn
@@ -5,6 +5,7 @@ v8_enable_backtrace = true
 v8_enable_disassembler = true
 v8_enable_object_print = true
 v8_enable_verify_heap = true
+v8_enable_slow_dchecks = true
 is_debug = true
 symbol_level = 0
 use_custom_libcxx = false

--- a/bin/s390x/ptrcompr_debug.gn
+++ b/bin/s390x/ptrcompr_debug.gn
@@ -5,6 +5,7 @@ v8_enable_backtrace = true
 v8_enable_disassembler = true
 v8_enable_object_print = true
 v8_enable_verify_heap = true
+v8_enable_slow_dchecks = true
 is_debug = true
 symbol_level = 0
 v8_enable_pointer_compression = true


### PR DESCRIPTION
Need to enable it after this CL as some unit tests started failing:
https://chromium-review.googlesource.com/c/v8/v8/+/5952933