### PR TITLE
Upgrade to py3.11 and install filecheck

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,7 +25,7 @@ RUN dnf -y install \
     wget \
     xz \
     git \
-    python39 \
+    python3.11 \
     ninja-build \
     make \
     cmake \
@@ -42,7 +42,8 @@ RUN dnf -y install ccache
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 
 # python dependencies
-RUN pip3 install httplib2 six requests
+python3 -m ensurepip
+RUN pip3 install httplib2 six requests filecheck
 
 # clone depot_tools and add it to your path
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git


### PR DESCRIPTION
This CL has introduced filecheck as a dependency: https://chromium-review.googlesource.com/c/v8/v8/+/6083883
Will need to upgrade to py >=10 too install it.